### PR TITLE
add support for oneof type name is Capitalized, and "_2nd" field name fits what protoc java generated

### DIFF
--- a/generator/src/main/kotlin/io/github/mscheong01/krotodc/util/DescriptorExtensions.kt
+++ b/generator/src/main/kotlin/io/github/mscheong01/krotodc/util/DescriptorExtensions.kt
@@ -182,7 +182,7 @@ val Descriptor.toDataClassImport: Import
  */
 val FieldDescriptor.javaFieldName: String
     get() {
-        val jsonName = this.jsonName
+        val jsonName = this.jsonName.snakeToCamelCaseNoRegex()
         /**
          * protobuf-java escapes special fields in order to avoid name clashes with Java/Protobuf keywords
          * @see https://github.com/protocolbuffers/protobuf/blob/2cf94fafe39eeab44d3ab83898aabf03ff930d7a/java/core/src/main/java/com/google/protobuf/DescriptorMessageInfoFactory.java#L629C1-L648

--- a/generator/src/main/kotlin/io/github/mscheong01/krotodc/util/FieldName.kt
+++ b/generator/src/main/kotlin/io/github/mscheong01/krotodc/util/FieldName.kt
@@ -50,6 +50,8 @@ internal fun fieldNameToJsonName(name: String): String {
             }
             result.append(ch)
             isNextUpperCase = false
+        } else if (i == 0) {
+            result.append(ch.lowercaseChar())
         } else {
             result.append(ch)
         }

--- a/generator/src/main/kotlin/io/github/mscheong01/krotodc/util/StringExtensions.kt
+++ b/generator/src/main/kotlin/io/github/mscheong01/krotodc/util/StringExtensions.kt
@@ -1,0 +1,22 @@
+package io.github.mscheong01.krotodc.util
+
+fun String.snakeToCamelCaseNoRegex(): String {
+    var preChar = '.' // tricks, because the first char could not be dot(.) in real case.
+    return this.fold(StringBuilder()) { acc, s ->
+        acc.let {
+            if (s == '_') {
+                return@let acc
+            } else if (preChar == '.') {
+                acc.append(s)
+            } else if (s.isDigit()) {
+                acc.append(s)
+            } else if (preChar == '_' || preChar.isDigit()) {
+                acc.append(s.uppercase())
+            } else {
+                acc.append(s)
+            }
+        }
+        preChar = s
+        acc
+    }.toString()
+}

--- a/generator/src/test/proto/test.proto
+++ b/generator/src/test/proto/test.proto
@@ -107,3 +107,12 @@ message DeprecatedMessage {
     Person oneof_person = 4;
   }
 }
+
+message Persons {
+  Person person = 1;
+  Person person_2nd = 2;
+  oneof TagCode {
+    string tag = 3;
+    string tag_2nd = 4;
+  }
+}


### PR DESCRIPTION
There were some cases I encountered in wild, I will illustrate using the following code as an example.
``` protobuf
message Persons {
  Person person = 1;
  Person person_2nd = 2;
  oneof TagCode {
    string tag = 3;
    string tag_2nd = 4;
  }
}
```
## oneof type
In the provided code, if the type name of "oneof" is capitalized (which is technically not recommended and may be considered illegal), the "krotoDC" fails to generate the code correctly. However, if we compare it with the code generated by the Protoc Java plugin for the "oneof" type, we observe that making the first character lowercase produces the same result as the Java plugin.
<img width="1080" alt="image" src="https://github.com/mscheong01/krotoDC/assets/2269615/6dafc4a8-1069-42f6-902b-7d06084fdb55">

## special field name like xx_2nd
In the provided code, if the field name follows the pattern "_{digit}{first_alphabet}{other_alphabets}", the "protoc" Java plugin converts the first alphabet of "xx_2nd" to uppercase, resulting in "xx2Nd". However, in the current implementation of the "krotoDC" code, the field name is converted to "xx2nd", which is not compatible with the original Java code.
<img width="1077" alt="image" src="https://github.com/mscheong01/krotoDC/assets/2269615/97004c89-050e-44ae-b8ec-e934e0b70a3a">

The draft PR serves as a reference, and it's important to note that the implementation is subject to change.
