### PR TITLE
add `@StubFor`annotation to generated gRPC stub classes

### DIFF
--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -84,9 +84,9 @@ protobuf {
         id("grpc") {
             artifact = "io.grpc:protoc-gen-grpc-java:${rootProject.ext["grpcJavaVersion"]}"
         }
-//        id("grpckt") {
-//            artifact = "io.grpc:protoc-gen-grpc-kotlin:${rootProject.ext["grpcJavaVersion"]}"
-//        }
+        id("grpckt") {
+            artifact = "io.grpc:protoc-gen-grpc-kotlin:${rootProject.ext["grpcKotlinVersion"]}:jdk8@jar"
+        }
         id("krotoDC") {
             path = tasks.jar.get().archiveFile.get().asFile.absolutePath
         }
@@ -99,7 +99,7 @@ protobuf {
 
             it.plugins {
                 id("grpc")
-//                id("grpckt")
+                id("grpckt")
                 id("krotoDC")
             }
         }

--- a/generator/src/main/kotlin/io/github/mscheong01/krotodc/specgenerators/type/ClientStubGenerator.kt
+++ b/generator/src/main/kotlin/io/github/mscheong01/krotodc/specgenerators/type/ClientStubGenerator.kt
@@ -34,8 +34,10 @@ import io.github.mscheong01.krotodc.specgenerators.file.DataClassGenerator
 import io.github.mscheong01.krotodc.specgenerators.function.MessageToDataClassFunctionGenerator
 import io.github.mscheong01.krotodc.specgenerators.function.MessageToProtoFunctionGenerator
 import io.github.mscheong01.krotodc.util.descriptorCode
+import io.github.mscheong01.krotodc.util.grpcClass
 import io.grpc.kotlin.AbstractCoroutineStub
 import io.grpc.kotlin.ClientCalls
+import io.grpc.kotlin.StubFor
 import kotlinx.coroutines.flow.Flow
 
 class ClientStubGenerator : TypeSpecGenerator<ServiceDescriptor> {
@@ -72,6 +74,11 @@ class ClientStubGenerator : TypeSpecGenerator<ServiceDescriptor> {
                 .addParameter("callOptions", io.grpc.CallOptions::class)
                 .returns(TypeVariableName(className))
                 .addStatement("return %T(channel, callOptions)", TypeVariableName(className))
+                .build()
+        )
+        typeBuilder.addAnnotation(
+            AnnotationSpec.builder(StubFor::class)
+                .addMember("%T::class", descriptor.grpcClass)
                 .build()
         )
 


### PR DESCRIPTION
Some frameworks like Armeria depends on the `io.grpc.kotlin.StubFor`on grpc-kotlin stubs to retrieve information about the java gRPC class. Adding the same annotation to krotodc generated stubs would ensure compatibility.