### PR TITLE
add `@JvmOverloads`annotation to stub primary constructor

### DIFF
--- a/generator/src/main/kotlin/io/github/mscheong01/krotodc/specgenerators/type/ClientStubGenerator.kt
+++ b/generator/src/main/kotlin/io/github/mscheong01/krotodc/specgenerators/type/ClientStubGenerator.kt
@@ -57,6 +57,7 @@ class ClientStubGenerator : TypeSpecGenerator<ServiceDescriptor> {
                             .defaultValue("%M", io.grpc.CallOptions::class.member("DEFAULT"))
                             .build()
                     )
+                    .addAnnotation(JvmOverloads::class)
                     .build()
             )
             .addSuperclassConstructorParameter("channel")


### PR DESCRIPTION
grpc-kotlin generated stubs has the `@JvmOverloads`annotation on its primary constructor (https://github.com/grpc/grpc-kotlin/blob/e12115cd3f9725ff6da5371c22552133c978f3f5/compiler/src/main/java/io/grpc/kotlin/generator/GrpcClientStubGenerator.kt#L128)
Armeria finds the constructor with a single parameter using reflection(https://github.com/line/armeria/blob/32568f9a6e84ecbfa1b765d602d90bb81d6c75a3/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/KotlinGrpcClientStubFactory.java#L36). Without this annotation, this code fails to find the appropriate constructor, leading to an error