### PR TITLE
fix potential compile failure for long protobuf message name

### DIFF
--- a/generator/src/main/kotlin/io/github/mscheong01/krotodc/specgenerators/function/FromJsonFunctionGenerator.kt
+++ b/generator/src/main/kotlin/io/github/mscheong01/krotodc/specgenerators/function/FromJsonFunctionGenerator.kt
@@ -42,7 +42,10 @@ class FromJsonFunctionGenerator : FunSpecGenerator<Descriptor> {
             )
             .receiver(generatedTypeCompanion)
             .returns(generatedType)
-        functionBuilder.addCode("return %L.newBuilder().apply { JsonFormat.parser().ignoringUnknownFields().merge(json, this@apply) }.build().toDataClass();\n", protoType)
+        functionBuilder.addCode("return %L.newBuilder()\n", protoType)
+        functionBuilder.addCode("       .apply {\n")
+        functionBuilder.addCode("           JsonFormat.parser().ignoringUnknownFields().merge(json, this@apply)\n")
+        functionBuilder.addCode("       }.build().toDataClass();\n")
 
         imports.add(Import("com.google.protobuf.util", listOf("JsonFormat")))
         return FunSpecsWithImports(

--- a/generator/src/test/proto/very_long_message.proto
+++ b/generator/src/test/proto/very_long_message.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "com.example.application.system.types";
+option java_outer_classname = "VeryLongMessageNameProto";
+
+package com.example.application.system.types;
+
+message VeryVeryLongTestProtocolBuffersMessageName {
+  repeated string type = 1;
+}


### PR DESCRIPTION
before:
```kotlin
public fun KrotodcVeryVeryLongTestProtocolBuffersMessageName.Companion.fromJson(json: String):
    KrotodcVeryVeryLongTestProtocolBuffersMessageName =
    com.example.application.system.types.VeryVeryLongTestProtocolBuffersMessageName.newBuilder().apply
    { JsonFormat.parser().ignoringUnknownFields().merge(json, this@apply) }.build().toDataClass();
```
// compile error

after:
```kotlin
public fun KrotodcVeryVeryLongTestProtocolBuffersMessageName.Companion.fromJson(json: String):
    KrotodcVeryVeryLongTestProtocolBuffersMessageName =
    com.example.application.system.types.VeryVeryLongTestProtocolBuffersMessageName.newBuilder()
       .apply {
           JsonFormat.parser().ignoringUnknownFields().merge(json, this@apply)
       }.build().toDataClass();
```