### PR TITLE
Compatibility with protoc 4.30.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,9 +11,9 @@ if (project.hasProperty("releaseVersion")) {
     version = project.property("releaseVersion") as String
 }
 
-ext["grpcJavaVersion"] = "1.66.0"
-ext["grpcKotlinVersion"] = "1.4.1"
-ext["protobufVersion"] = "3.25.4"
+ext["grpcJavaVersion"] = "1.70.0"
+ext["grpcKotlinVersion"] = "1.4.0"
+ext["protobufVersion"] = "4.30.1"
 ext["coroutinesVersion"] = "1.8.1"
 ext["kotlinPoetVersion"] = "1.18.1"
 

--- a/core/src/main/kotlin/io/github/mscheong01/krotodc/KrotoDC.kt
+++ b/core/src/main/kotlin/io/github/mscheong01/krotodc/KrotoDC.kt
@@ -1,9 +1,9 @@
 package io.github.mscheong01.krotodc
 
-import com.google.protobuf.GeneratedMessageV3
+import com.google.protobuf.GeneratedMessage
 import kotlin.reflect.KClass
 
 @Target(AnnotationTarget.CLASS)
 annotation class KrotoDC(
-    val forProto: KClass<out GeneratedMessageV3>
+    val forProto: KClass<out GeneratedMessage>
 )

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     implementation("io.grpc:grpc-kotlin-stub:${rootProject.ext["grpcKotlinVersion"]}")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${rootProject.ext["coroutinesVersion"]}")
     implementation("io.grpc:grpc-protobuf:${rootProject.ext["grpcJavaVersion"]}")
-    implementation("io.github.mscheong01:krotoDC-core:1.2.0-protoc-4.30.1")
+    implementation("io.github.mscheong01:krotoDC-core:1.1.1")
     runtimeOnly("io.grpc:grpc-netty:${rootProject.ext["grpcJavaVersion"]}")
 
     testImplementation("javax.annotation:javax.annotation-api:1.3.2")
@@ -38,7 +38,7 @@ protobuf {
             artifact = "io.grpc:protoc-gen-grpc-java:${rootProject.ext["grpcJavaVersion"]}"
         }
         id("krotoDC") {
-            artifact = "io.github.mscheong01:protoc-gen-krotoDC:1.2.0-protoc-4.30.1:jdk8@jar"
+            artifact = "io.github.mscheong01:protoc-gen-krotoDC:1.1.1:jdk8@jar"
         }
     }
     generateProtoTasks {

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -11,8 +11,13 @@ dependencies {
 //    implementation(kotlin("stdlib"))
 //    implementation("io.grpc:grpc-protobuf:${rootProject.ext["grpcJavaVersion"]}")
     // https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java
-    implementation("com.google.protobuf:protobuf-java:${rootProject.ext["protobufVersion"]}")
-    implementation("com.google.protobuf:protobuf-java-util:${rootProject.ext["protobufVersion"]}")
+
+    // TODO: update example protobuf dependency to 4+
+    // implementation("com.google.protobuf:protobuf-java:${rootProject.ext["protobufVersion"]}")
+    // implementation("com.google.protobuf:protobuf-java-util:${rootProject.ext["protobufVersion"]}")
+    implementation("com.google.protobuf:protobuf-java:3.25.4")
+    implementation("com.google.protobuf:protobuf-java-util:3.25.4")
+
     implementation("io.grpc:grpc-stub:${rootProject.ext["grpcJavaVersion"]}")
     implementation("io.grpc:grpc-kotlin-stub:${rootProject.ext["grpcKotlinVersion"]}")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${rootProject.ext["coroutinesVersion"]}")
@@ -31,7 +36,8 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:${rootProject.ext["protobufVersion"]}"
+        // artifact = "com.google.protobuf:protoc:${rootProject.ext["protobufVersion"]}"
+        artifact = "com.google.protobuf:protoc:3.25.4"
     }
     plugins {
         id("grpc") {

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     implementation("io.grpc:grpc-kotlin-stub:${rootProject.ext["grpcKotlinVersion"]}")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${rootProject.ext["coroutinesVersion"]}")
     implementation("io.grpc:grpc-protobuf:${rootProject.ext["grpcJavaVersion"]}")
-    implementation("io.github.mscheong01:krotoDC-core:1.1.1")
+    implementation("io.github.mscheong01:krotoDC-core:1.2.0-SNAPSHOT")
     runtimeOnly("io.grpc:grpc-netty:${rootProject.ext["grpcJavaVersion"]}")
 
     testImplementation("javax.annotation:javax.annotation-api:1.3.2")
@@ -37,7 +37,7 @@ protobuf {
             artifact = "io.grpc:protoc-gen-grpc-java:${rootProject.ext["grpcJavaVersion"]}"
         }
         id("krotoDC") {
-            artifact = "io.github.mscheong01:protoc-gen-krotoDC:1.1.1:jdk8@jar"
+            artifact = "io.github.mscheong01:protoc-gen-krotoDC:1.2.0-SNAPSHOT:jdk8@jar"
         }
     }
     generateProtoTasks {

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -4,6 +4,7 @@ repositories {
     maven {
         url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
     }
+    mavenLocal()
 }
 
 dependencies {
@@ -16,7 +17,7 @@ dependencies {
     implementation("io.grpc:grpc-kotlin-stub:${rootProject.ext["grpcKotlinVersion"]}")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${rootProject.ext["coroutinesVersion"]}")
     implementation("io.grpc:grpc-protobuf:${rootProject.ext["grpcJavaVersion"]}")
-    implementation("io.github.mscheong01:krotoDC-core:1.2.0-SNAPSHOT")
+    implementation("io.github.mscheong01:krotoDC-core:1.2.0-protoc-4.30.1")
     runtimeOnly("io.grpc:grpc-netty:${rootProject.ext["grpcJavaVersion"]}")
 
     testImplementation("javax.annotation:javax.annotation-api:1.3.2")
@@ -37,7 +38,7 @@ protobuf {
             artifact = "io.grpc:protoc-gen-grpc-java:${rootProject.ext["grpcJavaVersion"]}"
         }
         id("krotoDC") {
-            artifact = "io.github.mscheong01:protoc-gen-krotoDC:1.2.0-SNAPSHOT:jdk8@jar"
+            artifact = "io.github.mscheong01:protoc-gen-krotoDC:1.2.0-protoc-4.30.1:jdk8@jar"
         }
     }
     generateProtoTasks {

--- a/generator/src/main/kotlin/io/github/mscheong01/krotodc/KrotoDCCodeGenerator.kt
+++ b/generator/src/main/kotlin/io/github/mscheong01/krotodc/KrotoDCCodeGenerator.kt
@@ -16,7 +16,6 @@ package io.github.mscheong01.krotodc
 import com.google.protobuf.Descriptors
 import com.google.protobuf.compiler.PluginProtos
 import com.squareup.kotlinpoet.FileSpec
-import io.github.mscheong01.krotodc.specgenerators.FileSpecGenerator
 import io.github.mscheong01.krotodc.specgenerators.file.ConverterGenerator
 import io.github.mscheong01.krotodc.specgenerators.file.DataClassGenerator
 import io.github.mscheong01.krotodc.specgenerators.file.GrpcKrotoGenerator

--- a/generator/src/main/kotlin/io/github/mscheong01/krotodc/KrotoDCCodeGenerator.kt
+++ b/generator/src/main/kotlin/io/github/mscheong01/krotodc/KrotoDCCodeGenerator.kt
@@ -23,16 +23,16 @@ import io.github.mscheong01.krotodc.specgenerators.file.GrpcKrotoGenerator
 
 object KrotoDCCodeGenerator {
 
-    val subGenerators = listOf<FileSpecGenerator>(
+    val subGenerators = listOf(
         DataClassGenerator(),
         GrpcKrotoGenerator(),
-//        io.github.mscheong01.krotodc.subgenerators.WrappedStubGenerator(),
         ConverterGenerator()
     )
 
     fun generateCode(request: PluginProtos.CodeGeneratorRequest) {
         val fileNameToDescriptor = mutableMapOf<String, Descriptors.FileDescriptor>()
-        request.protoFileList.toList()
+        request.protoFileList
+            .toList()
             .forEach { file ->
                 val deps = file.dependencyList.map { dep ->
                     fileNameToDescriptor[dep]

--- a/generator/src/main/kotlin/io/github/mscheong01/krotodc/specgenerators/file/DataClassGenerator.kt
+++ b/generator/src/main/kotlin/io/github/mscheong01/krotodc/specgenerators/file/DataClassGenerator.kt
@@ -122,11 +122,11 @@ class DataClassGenerator : FileSpecGenerator {
                                     ParameterSpec.builder(
                                         it.jsonName,
                                         type
-                                    )
-                                        .defaultValue(default.code)
-                                        .build()
-                                )
-                                .build()
+                                    ).apply {
+                                        if (it.isKrotoDCOptional)
+                                            defaultValue(default.code)
+                                    }.build()
+                                ).build()
                         )
                         .addProperty(
                             PropertySpec.builder(
@@ -189,7 +189,10 @@ class DataClassGenerator : FileSpecGenerator {
                                 )
                             }
                         }
-                        .defaultValue(default.code).build()
+                        .apply {
+                            if (field.isKrotoDCOptional)
+                                defaultValue(default.code)
+                        }.build()
                 )
             dataClassBuilder.addProperty(
                 PropertySpec.builder(
@@ -227,6 +230,7 @@ class DataClassGenerator : FileSpecGenerator {
                 ClassName("com.google.protobuf", "ByteString"),
                 CodeWithImports.of("com.google.protobuf.ByteString.EMPTY")
             )
+
             Descriptors.FieldDescriptor.JavaType.ENUM -> {
                 val enumType = field.enumType
                     ?: throw IllegalStateException("Enum field $field does not have an enum type")
@@ -235,6 +239,7 @@ class DataClassGenerator : FileSpecGenerator {
                     CodeWithImports.of("${enumType.protobufJavaTypeName.canonicalName}.values()[0]")
                 )
             }
+
             Descriptors.FieldDescriptor.JavaType.MESSAGE -> {
                 if (field.isMapField) {
                     val keyType = field.messageType.findFieldByNumber(MAP_ENTRY_KEY_FIELD_NUMBER)

--- a/generator/src/main/kotlin/io/github/mscheong01/krotodc/specgenerators/file/DataClassGenerator.kt
+++ b/generator/src/main/kotlin/io/github/mscheong01/krotodc/specgenerators/file/DataClassGenerator.kt
@@ -123,8 +123,9 @@ class DataClassGenerator : FileSpecGenerator {
                                         it.jsonName,
                                         type
                                     ).apply {
-                                        if (it.isKrotoDCOptional)
+                                        if (it.isKrotoDCOptional) {
                                             defaultValue(default.code)
+                                        }
                                     }.build()
                                 ).build()
                         )
@@ -190,8 +191,9 @@ class DataClassGenerator : FileSpecGenerator {
                             }
                         }
                         .apply {
-                            if (field.isKrotoDCOptional)
+                            if (field.isKrotoDCOptional) {
                                 defaultValue(default.code)
+                            }
                         }.build()
                 )
             dataClassBuilder.addProperty(

--- a/generator/src/main/kotlin/io/github/mscheong01/krotodc/util/DescriptorExtensions.kt
+++ b/generator/src/main/kotlin/io/github/mscheong01/krotodc/util/DescriptorExtensions.kt
@@ -22,6 +22,13 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import io.github.mscheong01.krotodc.import.Import
 import io.github.mscheong01.krotodc.predefinedtypes.HandledPreDefinedType
+import java.lang.reflect.Method
+
+val hasOptionalKeywordMethod: Method = FieldDescriptor::class.java
+    .getDeclaredMethod("hasOptionalKeyword")
+    .apply {
+        isAccessible = true
+    }
 
 val FileDescriptor.javaPackage: String
     get() = when (val javaPackage = this.options.javaPackage) {
@@ -116,7 +123,7 @@ val EnumDescriptor.krotoDCTypeName: ClassName
 
 val FieldDescriptor.isKrotoDCOptional: Boolean
     get() {
-        if (this.hasOptionalKeyword()) {
+        if (hasOptionalKeywordMethod.invoke(this) as Boolean) {
             return true
         }
         if (this.isRepeated || isMapField) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 #Fri Mar 01 07:18:17 UTC 2024
 kotlin.code.style=official
-version=1.2.0-protoc-4.30.1
+version=1.2.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 #Fri Mar 01 07:18:17 UTC 2024
 kotlin.code.style=official
-version=1.2.0-SNAPSHOT
+version=1.2.0-protoc-4.30.1


### PR DESCRIPTION
- adapted to protoc version 4.30.1
- made so non-nullable fields don't have default values
- example module now also looks into maven local repo, so you don't need to publish your version to snapshot repo

![image](https://github.com/user-attachments/assets/a0000c67-0100-48d9-bb07-6e2a1ec49346)
