### PR TITLE
Add default value support to json output

### DIFF
--- a/generator/src/test/kotlin/io/github/mscheong01/krotodc/JsonConverterTest.kt
+++ b/generator/src/test/kotlin/io/github/mscheong01/krotodc/JsonConverterTest.kt
@@ -47,7 +47,7 @@ class JsonConverterTest {
             stringList = emptyList(),
             defaultValueNestedMessage = DefaultValueNestedMessage(
                 doubleField = 31.08,
-                booleanField = false,
+                booleanField = false
             )
         )
         val json = proto.toJson(includeDefaultValues = true)

--- a/generator/src/test/kotlin/io/github/mscheong01/krotodc/JsonConverterTest.kt
+++ b/generator/src/test/kotlin/io/github/mscheong01/krotodc/JsonConverterTest.kt
@@ -13,6 +13,9 @@
 // limitations under the License.
 package io.github.mscheong01.krotodc
 
+import com.example.defaultvaluestest.krotodc.DefaultValueNestedMessage
+import com.example.defaultvaluestest.krotodc.DefaultValueTest
+import com.example.defaultvaluestest.krotodc.defaultvaluetest.toJson
 import io.github.mscheong01.test.Person
 import io.github.mscheong01.test.krotodc.person.fromJson
 import io.github.mscheong01.test.krotodc.person.toDataClass
@@ -35,5 +38,21 @@ class JsonConverterTest {
         )
         val deserializedDataClass = io.github.mscheong01.test.krotodc.Person.fromJson(json)
         Assertions.assertThat(dataClass).isEqualTo(deserializedDataClass)
+    }
+
+    @Test
+    fun `test including default values in toJson call`() {
+        val proto = DefaultValueTest(
+            intField = 0,
+            stringList = emptyList(),
+            defaultValueNestedMessage = DefaultValueNestedMessage(
+                doubleField = 31.08,
+                booleanField = false,
+            )
+        )
+        val json = proto.toJson(includeDefaultValues = true)
+        Assertions.assertThat(json).isEqualTo(
+            "{\"intField\":0,\"stringList\":[],\"defaultValueNestedMessage\":{\"doubleField\":31.08,\"booleanField\":false}}"
+        )
     }
 }

--- a/generator/src/test/proto/default_values_test.proto
+++ b/generator/src/test/proto/default_values_test.proto
@@ -1,0 +1,28 @@
+// Copyright 2023 Minsoo Cheong
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+syntax = "proto3";
+
+
+package com.example.defaultvaluestest;
+
+message DefaultValueTest {
+  int32 int_field = 1;
+  repeated string string_list = 2;
+  DefaultValueNestedMessage default_value_nested_message = 3;
+}
+
+message DefaultValueNestedMessage {
+  double double_field = 1;
+  bool boolean_field = 2;
+}


### PR DESCRIPTION
Modified toJson function to include a boolean parameter `includeDefaultValues`. The parameter allows printing of default values in the json output. The parameter has a default value of false, this allows for backward compatibility since if the parameter is false, then the output will exclude default value.

Why propose the change?

In our project we use microservice and we have a logging service that logs failures that occur in the system. The logger logs the request and response jsons each service received and sent, when investigating the logs it can be tricky since fields with default values will be omitted from the output. Here's an example with two classes A and B:

```
data class A(
  val response: HttpResponse,
  val isA: Boolean = false,
)

data class B(
 val response: HttpResponse,
val isB: Boolean = false,
)
```

With the above classes, if we call A(response = OK).toJson() and B(response = OK, isB = false).toJson(), both of these calls will generate the following output and exclude the boolean fields since they are set to default values.

```
{
"response": "OK"
}
```

With the proposed change, calls to toJson() will still work the same way but now we'll also have the flexibility to make calls A(response = OK).toJson(includeDefaultValues = true) and B(response = OK, isB = false).toJson(includeDefaultValues = true), this will allow for the following outputs

```
{
"response": "OK",
"isA": false
}

{
"response": "OK",
"isB": false
}
```